### PR TITLE
FROM buildpack-deps to allow all node/python dependencies install

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM buildpack-deps:jessie
 
 RUN apt-get update && apt-get install -y xvfb chromium
 


### PR DESCRIPTION
Many depencies doesn't install on debian:jessie, buildpack-deps:jessie contain required depencies for almost all npm or pip modules.